### PR TITLE
fix: render LinkedIn demos via embed URL (CSP iframe block)

### DIFF
--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -6,6 +6,17 @@ function hostnameOf(url) {
   try { return new URL(url).hostname; } catch { return null; }
 }
 
+function toEmbedUrl(url) {
+  if (!url) return url;
+  const activity = url.match(/urn:li:activity:(\d+)/);
+  if (activity) return `https://www.linkedin.com/embed/feed/update/urn:li:activity:${activity[1]}`;
+  const ugc = url.match(/ugcPost[-:](\d+)/);
+  if (ugc) return `https://www.linkedin.com/embed/feed/update/urn:li:ugcPost:${ugc[1]}`;
+  const share = url.match(/[-:]share[-:](\d+)/i);
+  if (share) return `https://www.linkedin.com/embed/feed/update/urn:li:share:${share[1]}`;
+  return url;
+}
+
 function sectionNumberer() {
   let n = 0;
   return () => String(++n).padStart(2, '0');
@@ -157,7 +168,7 @@ export default function Projects() {
             <iframe
               className="t-demo-iframe"
               title={project.demo.title}
-              src={project.demo.url}
+              src={toEmbedUrl(project.demo.url)}
               loading="lazy"
             />
           )}

--- a/src/projects_array.ts
+++ b/src/projects_array.ts
@@ -60,7 +60,7 @@ export const projects_array: Projects_Array = [
     metric: 'helped close multiple >$100M ARR customers · grew usage 400%',
     demo: {
       title: "Payflow Platform Demo",
-      url: 'https://www.linkedin.com/posts/bennett-bishop_payflow-demo-payflow-demo-ugcPost-7404928123655532544-QCy4',
+      url: 'https://www.linkedin.com/feed/update/urn:li:activity:7404928529076875264/',
     },
     tools: [
       {name: 'Python', logo: `${process.env.PUBLIC_URL}/icons/Python.png`},


### PR DESCRIPTION
## Summary

The Payflow project demo iframe was blocked by LinkedIn's `frame-ancestors` CSP — regular post URLs can't be embedded. Fix:

- **`src/pages/Projects.js`** — adds a `toEmbedUrl()` helper that rewrites LinkedIn `activity`, `ugcPost`, and `share` URLs to their `/embed/feed/update/...` equivalents at render time. The data file keeps the human-readable URL.
- **`src/projects_array.ts`** — swaps the Payflow demo URL to the new activity ID (`7404928529076875264`).

## Test plan

- [ ] After merge + deploy, open `/projects/payflow` on the live site
- [ ] Confirm the demo iframe loads (no CSP `frame-ancestors` error in console)
- [ ] Confirm the video plays inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)