### PR TITLE
feat: full-color photo carousel with click-to-zoom lightbox

### DIFF
--- a/src/components/aboutMeSection.js
+++ b/src/components/aboutMeSection.js
@@ -1,4 +1,20 @@
+import { useEffect, useState } from 'react'
+
 export default function AboutMeSection() {
+  const [lightboxPhoto, setLightboxPhoto] = useState(null)
+
+  useEffect(() => {
+    if (!lightboxPhoto) return
+    const onKey = (e) => { if (e.key === 'Escape') setLightboxPhoto(null) }
+    document.addEventListener('keydown', onKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [lightboxPhoto])
+
   const photos = [
     { src: 'aboutMe/tuna_pic.jpg', alt: 'Fishing trip' },
     { src: 'aboutMe/rugby_pic.jpg', alt: 'UCSB rugby' },
@@ -30,16 +46,40 @@ export default function AboutMeSection() {
       <div className="t-filmstrip" style={{ '--frame-count': photos.length }}>
         <div className="t-filmstrip-track" aria-hidden="false">
           {reel.map((p, i) => (
-            <div
+            <button
+              type="button"
               key={`${p.src}-${i}`}
               className="t-filmstrip-frame"
               style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/${p.src})` }}
-              role="img"
-              aria-label={p.alt}
+              aria-label={`Expand ${p.alt}`}
+              onClick={() => setLightboxPhoto(p)}
             />
           ))}
         </div>
       </div>
+
+      {lightboxPhoto && (
+        <div
+          className="t-lightbox"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${lightboxPhoto.alt} full size`}
+          onClick={() => setLightboxPhoto(null)}
+        >
+          <button
+            type="button"
+            className="t-lightbox-close"
+            onClick={(e) => { e.stopPropagation(); setLightboxPhoto(null) }}
+            autoFocus
+          >close</button>
+          <img
+            className="t-lightbox-img"
+            src={`${process.env.PUBLIC_URL}/${lightboxPhoto.src}`}
+            alt={lightboxPhoto.alt}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
     </section>
   )
 }

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -199,15 +199,18 @@ img { max-width: 100%; display: block; }
   width: max-content;
   animation: filmstrip-scroll 80s linear infinite;
 }
-.t-filmstrip-track:hover { animation-play-state: paused; }
 .t-filmstrip-frame {
   flex: 0 0 var(--frame-w);
   aspect-ratio: 4/3;
   background: #222 center/cover no-repeat;
-  filter: grayscale(.3) contrast(1.05);
-  transition: filter .2s;
+  filter: contrast(1.05);
+  transition: filter .2s, transform .2s;
+  border: none;
+  padding: 0;
+  cursor: zoom-in;
 }
-.t-filmstrip-frame:hover { filter: grayscale(0) contrast(1.1); }
+.t-filmstrip-frame:hover { filter: contrast(1.1) brightness(1.05); }
+.t-filmstrip-frame:focus-visible { outline: 1px solid var(--accent); outline-offset: 2px; }
 @keyframes filmstrip-scroll {
   from { transform: translate3d(0, 0, 0); }
   to   { transform: translate3d(calc(-1 * (var(--frame-w) + 1px) * var(--frame-count)), 0, 0); }


### PR DESCRIPTION
## Summary
- Photo carousel renders in full color by default instead of being desaturated until hover
- Carousel keeps spinning when the cursor is over it (removed hover-pause)
- Clicking a photo opens it in a full-screen lightbox (esc / click backdrop / close button to dismiss), mirroring the existing project-page lightbox pattern

## Pre-Landing Review
No issues. Lightbox mirrors `Projects.js` pattern: useEffect cleanup, escape handler, body overflow lock. A11y preserved (role=dialog, aria-modal, aria-label, focus outline).

## Test plan
- [x] `yarn build` succeeds (75.89 kB JS / 3.57 kB CSS gzipped, no warnings beyond existing yarn deprecation notice)
- [ ] Visit `/#about` and confirm photos look colorful with the carousel still scrolling under the cursor
- [ ] Click a photo and verify the lightbox opens; press esc and click the backdrop to confirm both dismiss it

🤖 Generated with [Claude Code](https://claude.com/claude-code)